### PR TITLE
#5 - 페이지합치기(venv)

### DIFF
--- a/Covid_Predict/myvenv/myvenv/pyvenv.cfg
+++ b/Covid_Predict/myvenv/myvenv/pyvenv.cfg
@@ -1,0 +1,3 @@
+home = C:\Users\dana0\AppData\Local\Programs\Python\Python310
+include-system-site-packages = false
+version = 3.10.4


### PR DESCRIPTION
venv 가상환경 설정을 위해 zip파일 올립니다. 해당 파일이 없으면, venv 실행이 불가능하여 올립니다.